### PR TITLE
Save the date earlier in the script

### DIFF
--- a/controller/notebook_versioner.sh
+++ b/controller/notebook_versioner.sh
@@ -27,6 +27,10 @@ echo "Starting notebook versioner."
 # Making sure we have the right timezone
 cp /usr/share/zoneinfo/America/New_York /etc/localtime
 
+# And saving the variable earlier in the script so we don't
+# cross over into the next day before Dropbox is finished syncing
+DATE="$(date +'%Y-%m-%d')"
+
 # Wait until Dropbox is finished syncing before doing the commit
 wait_for_dropbox
 
@@ -34,7 +38,7 @@ echo "Commiting and pushing..."
 cd /root/Dropbox/notebook
 git config core.fileMode false
 git add --all
-git commit -m $(date +'%Y-%m-%d') --author "Ryan Hefner <rhefner1@gmail.com>"
+git commit -m ${DATE} --author "Ryan Hefner <rhefner1@gmail.com>"
 git push origin master
 
 # Wait until Dropbox is finished syncing before finishing


### PR DESCRIPTION
Just in case the Dropbox sync takes longer than 10 minutes
(and crosses over to the next day), we still want to have
the right commit date.

Fixes #10