### PR TITLE
Increase Dropbox Timeout

### DIFF
--- a/controller/notebook_versioner.sh
+++ b/controller/notebook_versioner.sh
@@ -9,7 +9,7 @@ wait_for_dropbox() {
   while [ "$(/root/dropbox.py status)" != 'Up to date' ]
   do
     let i+=1
-    if [ "$i" -ge 150 ]
+    if [ "$i" -ge 900 ]
       then
         echo "Dropbox timed out. Exiting..."
         exit 1


### PR DESCRIPTION
Instead of giving Dropbox 2.5 minutes to update (ridiculous), we
now give it 15 minutes.